### PR TITLE
Typo causing compilation to fail

### DIFF
--- a/stf/src/search.cxx
+++ b/stf/src/search.cxx
@@ -106,7 +106,7 @@ Int_t* SearchFullSet(Options &opt, const Int_t nbodies, Particle *&Part, Int_t &
     GetVelocityDensity(opt, nbodies, Part,tree);
     for (i=0;i<nbodies;i++) Part[i].SetType(storetype[i]);
     delete[] storetype;
-    delete[] numingorup;
+    delete[] numingroup;
     }
 #endif
     delete tree;


### PR DESCRIPTION
Small spelling mistake causing compilation to fail when  MPI="off". Still fails due to-

search.cxx: In function ‘Int_t* SearchFullSet(Options&, Int_t, NBody::Particle*&, Int_t&)’:
search.cxx:94:14: error: cannot convert ‘short int*’ to ‘Int_t* {aka long long int*}’ in assignment
     storetype=new short[nbodies];
