### PR TITLE
HDF5 velocity dataset names

### DIFF
--- a/stf/src/hdfitems.h
+++ b/stf/src/hdfitems.h
@@ -324,8 +324,8 @@ struct HDF_Part_Info {
         //gas
         if (ptype==HDFGASTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
-            else names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
             names[itemp++]=H5std_string("Density");
@@ -392,8 +392,8 @@ struct HDF_Part_Info {
         //dark matter
         if (ptype==HDFDMTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
-            else names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             if (hdfnametype==HDFSWIFTEAGLENAMES) {
                 names[itemp++]=H5std_string("Masses");
@@ -412,8 +412,8 @@ struct HDF_Part_Info {
         //also dark matter particles
         if (ptype==HDFDM1TYPE ||ptype==HDFDM2TYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
-            else names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
             if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
@@ -427,8 +427,8 @@ struct HDF_Part_Info {
         }
         if (ptype==HDFSTARTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
-            else names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
             //for stars assume star formation and metallicy are position 4, 5 in name array
@@ -468,8 +468,8 @@ struct HDF_Part_Info {
         }
         if (ptype==HDFBHTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
-            else names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
             if (hdfnametype==HDFILLUSTISNAMES) {

--- a/stf/src/hdfitems.h
+++ b/stf/src/hdfitems.h
@@ -324,7 +324,7 @@ struct HDF_Part_Info {
         //gas
         if (ptype==HDFGASTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=H5std_string("Velocity");
             else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
@@ -392,7 +392,7 @@ struct HDF_Part_Info {
         //dark matter
         if (ptype==HDFDMTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=H5std_string("Velocity");
             else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             if (hdfnametype==HDFSWIFTEAGLENAMES) {
@@ -412,7 +412,7 @@ struct HDF_Part_Info {
         //also dark matter particles
         if (ptype==HDFDM1TYPE ||ptype==HDFDM2TYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=H5std_string("Velocity");
             else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
@@ -427,7 +427,7 @@ struct HDF_Part_Info {
         }
         if (ptype==HDFSTARTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=H5std_string("Velocity");
             else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
@@ -468,7 +468,7 @@ struct HDF_Part_Info {
         }
         if (ptype==HDFBHTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocity");
+            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=H5std_string("Velocity");
             else names[itemp++]=H5std_string("Velocities");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");

--- a/stf/src/hdfitems.h
+++ b/stf/src/hdfitems.h
@@ -324,7 +324,7 @@ struct HDF_Part_Info {
         //gas
         if (ptype==HDFGASTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES || hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
+            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
             else names[itemp++]=H5std_string("Velocity");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
@@ -392,7 +392,7 @@ struct HDF_Part_Info {
         //dark matter
         if (ptype==HDFDMTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES || hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
+            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
             else names[itemp++]=H5std_string("Velocity");
             names[itemp++]=H5std_string("ParticleIDs");
             if (hdfnametype==HDFSWIFTEAGLENAMES) {
@@ -412,7 +412,7 @@ struct HDF_Part_Info {
         //also dark matter particles
         if (ptype==HDFDM1TYPE ||ptype==HDFDM2TYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES || hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
+            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
             else names[itemp++]=H5std_string("Velocity");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
@@ -427,7 +427,7 @@ struct HDF_Part_Info {
         }
         if (ptype==HDFSTARTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES || hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
+            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
             else names[itemp++]=H5std_string("Velocity");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");
@@ -468,7 +468,7 @@ struct HDF_Part_Info {
         }
         if (ptype==HDFBHTYPE) {
             names[itemp++]=H5std_string("Coordinates");
-            if(hdfnametype!=HDFEAGLENAMES || hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
+            if(hdfnametype!=HDFEAGLENAMES && hdfnametype!=HDFSWIFTEAGLENAMES) names[itemp++]=H5std_string("Velocities");
             else names[itemp++]=H5std_string("Velocity");
             names[itemp++]=H5std_string("ParticleIDs");
             names[itemp++]=H5std_string("Masses");


### PR DESCRIPTION
The logic in hdfitems.h that chooses between 'Velocity' and 'Velocities' for the name of the dataset with the particle velocities seems to be wrong. Currently the if statement will always be true and it will always use 'Velocities', so reading EAGLE snapshots fails.

It looks like the intent was to use Velocity if hdfnametype is HDFEAGLENAMES or HDFSWIFTEAGLENAMES, so here's a pull request that makes it do that. Although I'm not sure if this is the right behaviour for the HDFSWIFTEAGLENAMES case.