### PR TITLE
Use system-level hdf5 include and library directories if available.

### DIFF
--- a/stf/Makefile.config.template
+++ b/stf/Makefile.config.template
@@ -28,6 +28,16 @@ LOCALADIOS="on"
 LOCALXDR="on"
 #===========================================
 
+
+#===========================================
+#native (your operating system) libraries
+#===========================================
+#for using h5c++ -show to find your system level include and library files
+ifneq ($(LOCALHDF),"on")
+   HDFNATIVELIBS="on"
+endif
+#===========================================
+
 #===========================================
 #Adjust precision
 #===========================================
@@ -330,8 +340,18 @@ ifeq ($(HDFENABLE),"on")
 		# Comment out if your HDF5 library is version 1.10.0 or older
     C+FLAGS+= -DHDF5_NEWER_THAN_1_10_0
     C+LIBS+= -lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5 -lz -lrt -ldl
-    IFLAGS+= $(HDF_INCL)
-    LFLAGS+= $(HDF_LIBS)
+    ifeq ($(HDFNATIVELIBS),"on")
+       H5C+ = h5c++
+       # h5c++ (version 1.10.0-patch1+docs-3+deb9u1) does not have
+       # options to show include and library options separately;
+       # awk: $1=$(NF+1) replaces the first field by a null string
+       # and $0 prints the revised string
+       IFLAGS+=$(shell $(H5C+) -show |awk '{$$1=$$(NF+1); print $$0}')
+       LFLAGS+=$(shell $(H5C+) -show |awk '{$$1=$$(NF+1); print $$0}')
+    else
+       IFLAGS+= $(HDF_INCL)
+       LFLAGS+= $(HDF_LIBS)
+   endif
 endif
 
 ifeq ($(ADIOSENABLE),"on")


### PR DESCRIPTION
On Debian GNU/Linux 4.9.0 (stable = stretch), the HDF options
HDF_INCL = -I/usr/include/hdf5/serial/
HDF_LIBS = -L/usr/lib/x86_64-linux-gnu/hdf5/serial/
need to be added by hand to `Makefile.config` (copy of `Makefile.config.template`).
It would be better to find these automatically, using the `h5c++`
compiler front end, which is similar to the `mpic++` front end,
but appears to be less developed (single minus options, no separation
between compile and link options). Here is a proposed modification
of `Makefile.config.template` to do this. This works for me on
the swift-interface branch after setting `LOCALHDF="off"`, which
should be reasonably obvious to someone reading `Makefile.config.template`.