### PR TITLE
Fixes a few memory leaks in the VR library

### DIFF
--- a/src/buildandsortarrays.cxx
+++ b/src/buildandsortarrays.cxx
@@ -111,7 +111,8 @@ Int_t *BuildNoffset(const Int_t nbodies, Particle *Part, Int_t numgroups,Int_t *
         else Part[i].SetType(nbodies+1);//here move all particles not in groups to the back of the particle array
     }
     qsort(Part, nbodies, sizeof(Particle), TypeCompare);
-    noffset[0]=noffset[1]=0;
+    cout << numgroups << endl;
+    if (numgroups > 1) noffset[0]=noffset[1]=0;
     for (Int_t i=2;i<=numgroups;i++) noffset[i]=noffset[i-1]+numingroup[i-1];
     for (Int_t i=0;i<nbodies;i++) Part[i].SetType(storetype[Part[i].GetID()]);
     return noffset;

--- a/src/buildandsortarrays.cxx
+++ b/src/buildandsortarrays.cxx
@@ -115,6 +115,7 @@ Int_t *BuildNoffset(const Int_t nbodies, Particle *Part, Int_t numgroups,Int_t *
     if (numgroups > 1) noffset[0]=noffset[1]=0;
     for (Int_t i=2;i<=numgroups;i++) noffset[i]=noffset[i-1]+numingroup[i-1];
     for (Int_t i=0;i<nbodies;i++) Part[i].SetType(storetype[Part[i].GetID()]);
+    delete[] storetype;
     return noffset;
 }
 

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -490,7 +490,7 @@ void WriteGroupCatalog(Options &opt, const Int_t ngroups, Int_t *numingroup, Int
 
     //Write offsets for bound and unbound particles
     offset=new Int_t[ngroups+1];
-    offset[1]=0;
+    if(ngroups > 1) offset[1]=0;
     //note before had offsets at numingroup but to account for unbound particles use value of pglist at numingroup
     for (Int_t i=2;i<=ngroups;i++) offset[i]=offset[i-1]+pglist[i-1][numingroup[i-1]];
 

--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -3655,7 +3655,7 @@ Int_t **SortAccordingtoBindingEnergy(Options &opt, const Int_t nbodies, Particle
     for (i=0;i<nbodies;i++) Part[i].SetPID(storepid[Part[i].GetID()]);
     delete[] storepid;
 
-    noffset[0]=noffset[1]=0;
+    if (ngroup > 1) noffset[0]=noffset[1]=0;
     for (i=2;i<=ngroup;i++) noffset[i]=noffset[i-1]+numingroup[i-1];
 
     // for small groups interate over groups using openmp threads

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -431,8 +431,8 @@ groupinfo *InvokeVelociraptor(const int snapnum, char* outputname,
     //if inclusive halo mass required
     if (libvelociraptorOpt.iInclusiveHalo && ngroup>0) {
         CopyMasses(libvelociraptorOpt,nhalos,pdatahalos,pdata);
-        delete[] pdatahalos;
     }
+    delete[] pdatahalos;
 
     //
     // Search for baryons
@@ -482,7 +482,8 @@ groupinfo *InvokeVelociraptor(const int snapnum, char* outputname,
 
     for (Int_t i=1;i<=ngroup;i++) delete[] pglist[i];
     delete[] pglist;
-
+    delete[] pdata;
+    
 
     //store group information to return information to swift if required
     //otherwise, return NULL as pointer
@@ -518,6 +519,7 @@ groupinfo *InvokeVelociraptor(const int snapnum, char* outputname,
         free(s.cellloc);
         free(cell_node_ids);
         *numpartingroups=nig;
+	delete[] pfof;
         return NULL;
     }
 
@@ -553,7 +555,8 @@ groupinfo *InvokeVelociraptor(const int snapnum, char* outputname,
     libvelociraptorOpt.cellloc = NULL;
     free(s.cellloc);
     free(cell_node_ids);
-
+    delete[] pfof;
+    
     return group_info;
 }
 


### PR DESCRIPTION
There is one other big one left:

```
Direct leak of 12582912 byte(s) in 3 object(s) allocated from:
    #0 0x7f9c40567618 in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0618)
    #1 0x5555ace9853b in NBody::KDTree::FOFCriterionSetBasisForLinks(int (*)(NBody::Particle&, NBody::Particle&, double*), double*, long long&, long long, int, int, int (*)(NBody::Particle&, double*), int*, int\
*, int*, int*) /home/matthieu/Desktop/VELOCIraptor/VELOCIraptor-STF/NBodylib/src/KDTree/KDFOF.cxx:244
    #2 0x5555ace4c80f in SearchFullSet(Options&, long long, std::vector<NBody::Particle, std::allocator<NBody::Particle> >&, long long&) /home/matthieu/Desktop/VELOCIraptor/VELOCIraptor-STF/src/search.cxx:88
    #3 0x5555accea966 in InvokeVelociraptor /home/matthieu/Desktop/VELOCIraptor/VELOCIraptor-STF/src/swiftinterface.cxx:397
    #4 0x5555acbab129 in velociraptor_invoke /home/matthieu/Desktop/Swift-git/master/swiftsim/src/velociraptor_interface.c:513
    #5 0x5555acaec808 in engine_check_for_dumps /home/matthieu/Desktop/Swift-git/master/swiftsim/src/engine.c:3284
    #6 0x5555acafb3bd in engine_step /home/matthieu/Desktop/Swift-git/master/swiftsim/src/engine.c:3148
    #7 0x5555aca8067c in main /home/matthieu/Desktop/Swift-git/master/swiftsim/examples/main.c:1030
    #8 0x7f9c3dcb8b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
```

but I am not sure where it is best to release that memory. 

There are a few extra bytes here=and-there as well which at this stage may not matter. Altough it could be because they correspond to small arrays since there are no groups in the early snapshots.