### PR TITLE
Update the i/o naming convention to follow the update on the SWIFT side

### DIFF
--- a/src/hdfitems.h
+++ b/src/hdfitems.h
@@ -742,16 +742,34 @@ struct HDF_Part_Info {
         int itemp=0;
         //gas
         if (ptype==HDFGASTYPE) {
+
+	    // Positions
             names[itemp++]=string("Coordinates");
-            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
+
+	    // Velocities
+	    if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
-            names[itemp++]=string("ParticleIDs");
-            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Mass");
+
+	    // IDs
+	    names[itemp++]=string("ParticleIDs");
+
+	    // Masses
+	    if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Mass");
             else names[itemp++]=string("Masses");
-            names[itemp++]=string("Density");
-            names[itemp++]=string("InternalEnergy");
-            names[itemp++]=string("StarFormationRate");
-            //always place the metacallity at position 7 in naming array
+
+	    // Density
+	    if(hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("Densities");
+            else names[itemp++]=string("Density");
+
+	    // Internal energies
+            if(hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("InternalEnergies");
+	    else names[itemp++]=string("InternalEnergy");
+
+	    // SFR
+	    if(hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("StarFormationRates");
+            else names[itemp++]=string("StarFormationRate");
+	    
+            //Metallicity. Note always place at position 7 in naming array
             if (hdfnametype==HDFILLUSTISNAMES) {
                 propindex[HDFGASIMETAL]=itemp;
                 names[itemp++]=string("GFM_Metallicity");
@@ -808,38 +826,67 @@ struct HDF_Part_Info {
                 names[itemp++]=string("Dust_Masses");
                 names[itemp++]=string("Dust_Metallicity");//11 metals stored in this data set
             }
-            else if (hdfnametype==HDFEAGLENAMES || hdfnametype==HDFSWIFTEAGLENAMES) {
+            else if (hdfnametype==HDFEAGLENAMES) {
                 propindex[HDFGASIMETAL]=itemp;
                 names[itemp++]=string("Metallicity");
             }
+	    else if(hdfnametype==HDFSWIFTEAGLENAMES) {
+	      propindex[HDFGASIMETAL]=itemp;
+	      names[itemp++]=string("MetalMassFractions");
+	    }
         }
         //dark matter
         if (ptype==HDFDMTYPE) {
+
+	    // Positions
             names[itemp++]=string("Coordinates");
-            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
+
+	    // Velocities
+	    if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
-            names[itemp++]=string("ParticleIDs");
-            if (hdfnametype==HDFSWIFTEAGLENAMES) {
+
+	    // IDs
+	    names[itemp++]=string("ParticleIDs");
+
+	    // Masses
+            if (hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("Masses");
+            else if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
                 names[itemp++]=string("Masses");
-            }
-            if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
-                names[itemp++]=string("Masses");
+	    }
+
+	    // Potential
+	    if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
                 names[itemp++]=string("Potential");
             }
-            if (hdfnametype==HDFILLUSTISNAMES) {
+            else if (hdfnametype==HDFILLUSTISNAMES) {
                 names[itemp++]=string("Potential");
+	    }
+
+	    // Subfind properties
+	    if (hdfnametype==HDFILLUSTISNAMES) {
                 names[itemp++]=string("SubfindDensity");
                 names[itemp++]=string("SubfindHsml");
                 names[itemp++]=string("SubfindVelDisp");
             }
         }
+	
         //also dark matter particles
         if (ptype==HDFDM1TYPE ||ptype==HDFDM2TYPE) {
+
+   	    // Positions
             names[itemp++]=string("Coordinates");
+
+	    // Velocities
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
-            names[itemp++]=string("ParticleIDs");
+
+	    // IDs
+	    names[itemp++]=string("ParticleIDs");
+
+	    // Masses
             names[itemp++]=string("Masses");
+
+	    // Potential
             if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
                 names[itemp++]=string("Potential");
             }
@@ -850,12 +897,21 @@ struct HDF_Part_Info {
             names[itemp++]=string("TracerID");
         }
         if (ptype==HDFSTARTYPE) {
+
+	    // Positions
             names[itemp++]=string("Coordinates");
+
+	    // Velocities
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
+
+	    // IDs	    
             names[itemp++]=string("ParticleIDs");
+
+	    // Masses
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Mass");
             else names[itemp++]=string("Masses");
+	    
             //for stars assume star formation and metallicy are position 4, 5 in name array
             if (hdfnametype==HDFILLUSTISNAMES) {
                 propindex[HDFSTARIAGE]=itemp;
@@ -896,14 +952,29 @@ struct HDF_Part_Info {
                 propindex[HDFSTARIMETAL]=itemp;
                 names[itemp++]=string("Metallicity");
             }
+	    else if (hdfnametype==HDFSWIFTEAGLENAMES) {
+                propindex[HDFSTARIAGE]=itemp;
+                names[itemp++]=string("BirthScaleFactors");
+                propindex[HDFSTARIMETAL]=itemp;
+                names[itemp++]=string("MetalMassFractions");
+	    }
         }
         if (ptype==HDFBHTYPE) {
-            names[itemp++]=string("Coordinates");
+
+	    // Positions
+	    names[itemp++]=string("Coordinates");
+
+	    // Velocities
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
-            names[itemp++]=string("ParticleIDs");
+
+	    // IDs
+	    names[itemp++]=string("ParticleIDs");
+
+	    // Masses
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Mass");
             else names[itemp++]=string("Masses");
+	    
             if (hdfnametype==HDFILLUSTISNAMES) {
                 names[itemp++]=string("HostHaloMass");
                 names[itemp++]=string("Potential");

--- a/src/hdfitems.h
+++ b/src/hdfitems.h
@@ -743,32 +743,32 @@ struct HDF_Part_Info {
         //gas
         if (ptype==HDFGASTYPE) {
 
-	    // Positions
+            // Positions
             names[itemp++]=string("Coordinates");
 
-	    // Velocities
-	    if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
+            // Velocities
+            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
 
-	    // IDs
-	    names[itemp++]=string("ParticleIDs");
+            // IDs
+            names[itemp++]=string("ParticleIDs");
 
-	    // Masses
-	    if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Mass");
+            // Masses
+            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Mass");
             else names[itemp++]=string("Masses");
 
-	    // Density
-	    if(hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("Densities");
+            // Density
+            if(hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("Densities");
             else names[itemp++]=string("Density");
 
-	    // Internal energies
+            // Internal energies
             if(hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("InternalEnergies");
-	    else names[itemp++]=string("InternalEnergy");
+            else names[itemp++]=string("InternalEnergy");
 
-	    // SFR
-	    if(hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("StarFormationRates");
+            // SFR
+            if(hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("StarFormationRates");
             else names[itemp++]=string("StarFormationRate");
-	    
+
             //Metallicity. Note always place at position 7 in naming array
             if (hdfnametype==HDFILLUSTISNAMES) {
                 propindex[HDFGASIMETAL]=itemp;
@@ -830,63 +830,63 @@ struct HDF_Part_Info {
                 propindex[HDFGASIMETAL]=itemp;
                 names[itemp++]=string("Metallicity");
             }
-	    else if(hdfnametype==HDFSWIFTEAGLENAMES) {
-	      propindex[HDFGASIMETAL]=itemp;
-	      names[itemp++]=string("MetalMassFractions");
-	    }
+            else if(hdfnametype==HDFSWIFTEAGLENAMES) {
+              propindex[HDFGASIMETAL]=itemp;
+              names[itemp++]=string("MetalMassFractions");
+            }
         }
         //dark matter
         if (ptype==HDFDMTYPE) {
 
-	    // Positions
+            // Positions
             names[itemp++]=string("Coordinates");
 
-	    // Velocities
-	    if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
+            // Velocities
+            if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
 
-	    // IDs
-	    names[itemp++]=string("ParticleIDs");
+            // IDs
+            names[itemp++]=string("ParticleIDs");
 
-	    // Masses
+            // Masses
             if (hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("Masses");
             else if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
                 names[itemp++]=string("Masses");
-	    }
+            }
 
-	    // Potential
-	    if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
+            // Potential
+            if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
                 names[itemp++]=string("Potential");
             }
             else if (hdfnametype==HDFILLUSTISNAMES) {
                 names[itemp++]=string("Potential");
-	    }
+            }
 
-	    // Subfind properties
-	    if (hdfnametype==HDFILLUSTISNAMES) {
+            // Subfind properties
+            if (hdfnametype==HDFILLUSTISNAMES) {
                 names[itemp++]=string("SubfindDensity");
                 names[itemp++]=string("SubfindHsml");
                 names[itemp++]=string("SubfindVelDisp");
             }
         }
-	
+
         //also dark matter particles
         if (ptype==HDFDM1TYPE ||ptype==HDFDM2TYPE) {
 
-   	    // Positions
+            // Positions
             names[itemp++]=string("Coordinates");
 
-	    // Velocities
+            // Velocities
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
 
-	    // IDs
-	    names[itemp++]=string("ParticleIDs");
+            // IDs
+            names[itemp++]=string("ParticleIDs");
 
-	    // Masses
+            // Masses
             names[itemp++]=string("Masses");
 
-	    // Potential
+            // Potential
             if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
                 names[itemp++]=string("Potential");
             }
@@ -898,20 +898,20 @@ struct HDF_Part_Info {
         }
         if (ptype==HDFSTARTYPE) {
 
-	    // Positions
+            // Positions
             names[itemp++]=string("Coordinates");
 
-	    // Velocities
+            // Velocities
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
 
-	    // IDs	    
+            // IDs
             names[itemp++]=string("ParticleIDs");
 
-	    // Masses
+            // Masses
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Mass");
             else names[itemp++]=string("Masses");
-	    
+
             //for stars assume star formation and metallicy are position 4, 5 in name array
             if (hdfnametype==HDFILLUSTISNAMES) {
                 propindex[HDFSTARIAGE]=itemp;
@@ -952,29 +952,29 @@ struct HDF_Part_Info {
                 propindex[HDFSTARIMETAL]=itemp;
                 names[itemp++]=string("Metallicity");
             }
-	    else if (hdfnametype==HDFSWIFTEAGLENAMES) {
+            else if (hdfnametype==HDFSWIFTEAGLENAMES) {
                 propindex[HDFSTARIAGE]=itemp;
                 names[itemp++]=string("BirthScaleFactors");
                 propindex[HDFSTARIMETAL]=itemp;
                 names[itemp++]=string("MetalMassFractions");
-	    }
+            }
         }
         if (ptype==HDFBHTYPE) {
 
-	    // Positions
-	    names[itemp++]=string("Coordinates");
+            // Positions
+            names[itemp++]=string("Coordinates");
 
-	    // Velocities
+            // Velocities
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Velocity");
             else names[itemp++]=string("Velocities");
 
-	    // IDs
-	    names[itemp++]=string("ParticleIDs");
+            // IDs
+            names[itemp++]=string("ParticleIDs");
 
-	    // Masses
+            // Masses
             if(hdfnametype==HDFEAGLENAMES) names[itemp++]=string("Mass");
             else names[itemp++]=string("Masses");
-	    
+
             if (hdfnametype==HDFILLUSTISNAMES) {
                 names[itemp++]=string("HostHaloMass");
                 names[itemp++]=string("Potential");

--- a/src/hdfitems.h
+++ b/src/hdfitems.h
@@ -849,8 +849,8 @@ struct HDF_Part_Info {
             names[itemp++]=string("ParticleIDs");
 
             // Masses
-            if (hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("Masses");
-            else if (hdfnametype==HDFSIMBANAMES||hdfnametype==HDFMUFASANAMES) {
+            if (hdfnametype==HDFSWIFTEAGLENAMES || hdfnametype==HDFSIMBANAMES ||
+                hdfnametype==HDFMUFASANAMES) {
                 names[itemp++]=string("Masses");
             }
 


### PR DESCRIPTION
Does what it says on the tin. :) 

Just updated the constructor HDF_Part_Info() in hdfitems.h to use the new SWIFT names that have been in our master as of last week.  

I have also taken the liberty to add comments in-between the different variable names to keep things a bit clearer.

Note that there is something wrong in the logic between the two if-statements on lines 929 and 940. As I don't know which should be kept, I have left things as they are.