### PR TITLE
Updated BoxSize reader to account for vector types in SWIFT

### DIFF
--- a/src/hdfio.cxx
+++ b/src/hdfio.cxx
@@ -318,7 +318,17 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
                 cout<<" Expecting "<<endl;
                 for (j=0;j<NHDFTYPE+1;j++) cout<<hdf_gnames.names[j]<<endl;
             }
-            hdf_header_info[i].BoxSize = read_attribute<double>(Fhdf[i], hdf_header_info[i].names[hdf_header_info[i].IBoxSize]);
+              
+            /* Read the BoxSize */
+            if (opt.ihdfnameconvention == HDFSWIFTEAGLENAMES) {
+              /* SWIFT can have non-cubic boxes; but for cosmological runs they will always be cubes.
+              * This makes the BoxSize a vector attribute, with it containing three values, but they
+              * will always be the same. */
+              hdf_header_info[i].BoxSize = read_attribute_v<double>(Fhdf[i], hdf_header_info[i].names[hdf_header_info[i].IBoxSize])[0];
+            } else {
+              hdf_header_info[i].BoxSize = read_attribute<double>(Fhdf[i], hdf_header_info[i].names[hdf_header_info[i].IBoxSize]);
+            }
+
             vdoublebuff=read_attribute_v<double>(Fhdf[i], hdf_header_info[i].names[hdf_header_info[i].IMass]);
             for (k=0;k<NHDFTYPE;k++)hdf_header_info[i].mass[k]=vdoublebuff[k];
             if (opt.ihdfnameconvention==HDFSWIFTEAGLENAMES) {


### PR DESCRIPTION
Fixes #39 by replacing the BoxSize reader with one that handles the fact that SWIFT uses a vector of BoxSizes. In the GADGET standard, this value is just a double; in SWIFT the boxes can be non-cubic and so we store a value for all three dimensions.

As far as I can tell, this was returning a pointer to VR when accessing, which then of course caused many problems.