### PR TITLE
Fixed missing for loop to allow for compilation with stars

### DIFF
--- a/src/hdfio.cxx
+++ b/src/hdfio.cxx
@@ -935,7 +935,7 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
                       if (hdf_header_info[i].npart[k]-n<chunksize&&hdf_header_info[i].npart[k]-n>0)nchunk=hdf_header_info[i].npart[k]-n;
                       //setup hyperslab so that it is loaded into the buffer
                       HDF5ReadHyperSlabReal(doublebuff,partsdataset[i*NHDFTYPE+k], partsdataspace[i*NHDFTYPE+k], 1, 1, nchunk, n);
-                      Pbaryons[bcount++].SetZmet(doublebuff[nn]*zmetconversion);
+                      for (int nn=0;nn<nchunk;nn++) Pbaryons[bcount++].SetZmet(doublebuff[nn]*zmetconversion);
                     }
                   }
                   else {


### PR DESCRIPTION
Looks like this line was missing a loop over chunks. I don't actually know what this code does, but every other reading routine has it. 

This is only seen if trying to compile with `-DVR_WITH_STAR=ON`.