### PR TITLE
Only consider SFR > 0 when reading an EAGLE or SWIFT snapshot. 

### DIFF
--- a/src/hdfio.cxx
+++ b/src/hdfio.cxx
@@ -848,7 +848,7 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
                     if (hdf_header_info[i].npart[k]-n<chunksize&&hdf_header_info[i].npart[k]-n>0)nchunk=hdf_header_info[i].npart[k]-n;
                     //setup hyperslab so that it is loaded into the buffer
                     HDF5ReadHyperSlabReal(doublebuff,partsdataset[i*NHDFTYPE+k], partsdataspace[i*NHDFTYPE+k], 1, 1, nchunk, n);
-                    for (int nn=0;nn<nchunk;nn++) Part[count++].SetSFR(doublebuff[nn]);
+                    for (int nn=0;nn<nchunk;nn++) Part[count++].SetSFR(doublebuff[nn] > 0. ? doublebuff[nn] : 0.);
                   }
                 }
                 else {
@@ -1324,7 +1324,7 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
                       if (k==HDFGASTYPE) {
                         Pbuf[ibufindex].SetU(udoublebuff[nn]);
 #ifdef STARON
-                        Pbuf[ibufindex].SetSFR(SFRdoublebuff[nn]);
+                        Pbuf[ibufindex].SetSFR(SFRdoublebuff[nn] > 0. ? SFRdoublebuff[nn]: 0.);
                         Pbuf[ibufindex].SetZmet(Zdoublebuff[nn]);
 #endif
                     }
@@ -1439,7 +1439,7 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
                         if (k==HDFGASTYPE) {
                           Pbuf[ibufindex].SetU(udoublebuff[nn]);
 #ifdef STARON
-                          Pbuf[ibufindex].SetSFR(SFRdoublebuff[nn]);
+                          Pbuf[ibufindex].SetSFR(SFRdoublebuff[nn] > 0. ? SFRdoublebuff[nn] : 0.);
                           Pbuf[ibufindex].SetZmet(Zdoublebuff[nn]);
 #endif
                         }


### PR DESCRIPTION
Negative values encode different information that is of no interest for the halo catalogues.

Fixes #43. 