### PR TITLE
Correct parameters in sample_swiftdm_3dfof_subhalo.cfg example

### DIFF
--- a/examples/sample_swiftdm_3dfof_subhalo.cfg
+++ b/examples/sample_swiftdm_3dfof_subhalo.cfg
@@ -65,9 +65,9 @@ MPI_particle_total_buf_size=100000000
 ################################
 
 #how to search a simulation
-Particle_search_type=1 #search all particles, see allvars for other types
+Particle_search_type=2 #search all particles, see allvars for other types
 #for baryon search
-Baryon_searchflag=2 #if 1 search for baryons separately using phase-space search when identifying substructures, 2 allows special treatment in field FOF linking and phase-space substructure search, 0 treat the same as dark matter particles
+Baryon_searchflag=0 #if 1 search for baryons separately using phase-space search when identifying substructures, 2 allows special treatment in field FOF linking and phase-space substructure search, 0 treat the same as dark matter particles
 #for search for substruture
 Search_for_substructure=1 #if 0, end search once field objects are found
 #also useful for zoom simulations or simulations of individual objects, setting this flag means no field structure search is run


### PR DESCRIPTION
This modifies the sample_swiftdm_3dfof_subhalo.cfg example configuration to use Particle_search_type=2 and Baryon_Search_flag=0, which is more consistent with the other DM examples and also avoids triggering a possible bug which causes many halos to appear unbound.