### PR TITLE
Fix several memory leaks in the Swift interface

### DIFF
--- a/src/search.cxx
+++ b/src/search.cxx
@@ -1852,9 +1852,10 @@ void HaloCoreGrowth(Options &opt, const Int_t nsubset, Particle *&Partsubset, In
     KDTree *tcore;
     Coordinate x1;
     Double_t D2, dval, mval, weight;
-    Double_t *mcore=new Double_t[numgroupsbg+1];
-    Int_t *ncore=new Int_t[numgroupsbg+1];
-    Int_t newnumgroupsbg=0,*newcore=new Int_t[numgroupsbg+1];
+    std::vector<Double_t> mcore(numgroupsbg+1, 0.0);
+    std::vector<Int_t> ncore(numgroupsbg+1, 0);
+    std::vector<Int_t> newcore(numgroupsbg+1, 0);
+    Int_t newnumgroupsbg=0;
     int nsearch=opt.Nvel;
     int mincoresize;
     int tid,i;
@@ -1864,8 +1865,6 @@ void HaloCoreGrowth(Options &opt, const Int_t nsubset, Particle *&Partsubset, In
     Int_t nactivepart=nsubset;
     Int_t *noffset = NULL;
 
-
-    for (i=0;i<=numgroupsbg;i++)ncore[i]=mcore[i]=0;
     //determine the weights for the cores dispersions factors
     for (i=0;i<nsubset;i++) {
         if (pfofbg[i]>0) {
@@ -1929,8 +1928,6 @@ void HaloCoreGrowth(Options &opt, const Int_t nsubset, Particle *&Partsubset, In
 
             //if there are no active cores then return nothing
             if (nactive==0) {
-                delete[] mcore;
-                delete[] ncore;
                 delete[] noffset;
                 numgroupsbg=0;
                 return;
@@ -2164,9 +2161,6 @@ private(i,tid,Pval,x1,D2,dval,mval,pid,pidcore)
         if (newnumgroupsbg<=1) {
             numgroupsbg=0;
             delete pq;
-            delete[] mcore;
-            delete[] ncore;
-            delete[] newcore;
             delete[] noffset;
             return;
         }
@@ -2182,9 +2176,6 @@ private(i,tid,Pval,x1,D2,dval,mval,pid,pidcore)
         }
         numgroupsbg=newnumgroupsbg;
         delete pq;
-        delete[] mcore;
-        delete[] ncore;
-        delete[] newcore;
         delete[] noffset;
     }
 }

--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -2807,7 +2807,7 @@ void GetSOMasses(Options &opt, const Int_t nbodies, Particle *Part, Int_t ngroup
 {
     Particle *Pval;
     KDTree *tree;
-    Double_t *period=NULL;
+    Double_t period[3];
     Int_t i,j,k, nhalos = 0;
     if (opt.iverbose) {
         cout<<"Get inclusive masses"<<endl;
@@ -2873,7 +2873,6 @@ void GetSOMasses(Options &opt, const Int_t nbodies, Particle *Part, Int_t ngroup
 
     //set period
     if (opt.p>0) {
-        period=new Double_t[3];
         for (int j=0;j<3;j++) period[j]=opt.p;
 #ifdef USEMPI
         mpi_period=opt.p;

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -656,6 +656,7 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
     delete[] parentgid;
     delete[] stype;
     delete psldata;
+    delete[] numingroup;
 
     //store group information to return information to swift if required
     //otherwise, return NULL as pointer
@@ -667,7 +668,6 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
         free(s.cellloc);
         free(cell_node_ids);
         delete[] pfof;
-        delete[] numingroup;
         *numpartingroups=0;
         return NULL;
     }
@@ -694,7 +694,6 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
         free(s.cellloc);
         free(cell_node_ids);
         delete[] pfof;
-        delete[] numingroup;
         *numpartingroups=nig;
         return NULL;
     }

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -704,6 +704,7 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
         if (pfof[i]>0) parts[i].SetPID((pfof[i]+ngoffset)+libvelociraptorOpt.snapshotvalue);
         else parts[i].SetPID(0);
     }
+    delete [] pfof;
 #ifdef USEMPI
     if (NProcs > 1) {
     for (auto i=0;i<Nlocal; i++) parts[i].SetID((parts[i].GetSwiftTask()==ThisTask));


### PR DESCRIPTION
I've found that a small dmonly swift run with on-the-fly velociraptor eventually crashes with an out of memory error. Running in ddt shows that it's leaking memory on each velociraptor invocation, mainly because the pfof array in InvokeVelociraptorHydro doesn't get deallocated. This merge request fixes that and a couple of much smaller leaks.

There's still one more leak I haven't tracked down. The array returned by BuildPGList sometimes isn't deallocated but I don't know which call to BuildPGList is the problem.