### PR TITLE
Compilation fixes

### DIFF
--- a/src/gadgetio.cxx
+++ b/src/gadgetio.cxx
@@ -143,7 +143,7 @@ void ReadGadget(Options &opt, vector<Particle> &Part, const Int_t nbodies,Partic
     //if(i==ThisTask)
     if(ireadfile[i])
     {
-        if(opt.num_files>1) sprintf(buf,"%s.%d",opt.fname,i);
+        if(opt.num_files>1) sprintf(buf,"%s.%lld",opt.fname,i);
         else sprintf(buf,"%s",opt.fname);
         Fgad[i].open(buf,ios::in);
         if(!Fgad[i]) {

--- a/src/hdfio.cxx
+++ b/src/hdfio.cxx
@@ -805,7 +805,7 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
               }
               else {
 #ifdef NOMASS
-                  if (k==HDFDMTYPE) opt.MassValue = hdf_header_info[i].mass[k]
+		if (k==HDFDMTYPE) opt.MassValue = hdf_header_info[i].mass[k];
 #endif
                 for (int nn=0;nn<hdf_header_info[i].npart[k];nn++) Part[count++].SetMass(hdf_header_info[i].mass[k]);
               }

--- a/src/hdfitems.h
+++ b/src/hdfitems.h
@@ -331,7 +331,7 @@ static inline int whatisopen(hid_t fid) {
 
         if (cnt <= 0) return cnt;
 
-        printf("%d object(s) open\n", cnt);
+        printf("%zd object(s) open\n", cnt);
 
         objs = new hid_t[cnt];
 

--- a/src/localbgcomp.cxx
+++ b/src/localbgcomp.cxx
@@ -344,7 +344,7 @@ void DetermineDenVRatioDistribution(Options &opt,const Int_t nbodies, Particle *
             meanr=params[1];sdlow=sqrt(params[2]*params[3]);sdhigh=sqrt(params[2]);
             nfix=0;for (int j=0;j<nparams;j++) nfix+=(fixp[i][j]==1);
             oldchi2=chi2;
-            if(opt.iverbose>2) printf("chi2/dof=%e/%d, A=%e mu=%e var=%e s=%e\n",chi2,nbins-(nparams-nfix)-1,params[0],params[1],sqrt(params[2]),sqrt(params[3]));
+            if(opt.iverbose>2) printf("chi2/dof=%e/%lld, A=%e mu=%e var=%e s=%e\n",chi2,nbins-(nparams-nfix)-1,params[0],params[1],sqrt(params[2]),sqrt(params[3]));
         }
         //else if (oldchi2<chi2 && i>0) break;
         else {

--- a/src/ramsesio.cxx
+++ b/src/ramsesio.cxx
@@ -1028,8 +1028,8 @@ void ReadRamses(Options &opt, vector<Particle> &Part, const Int_t nbodies, Parti
     inreadsend=0;
 #endif
     for (i=0;i<opt.num_files;i++) if (ireadfile[i]) {
-        sprintf(buf1,"%s/amr_%s.out%s%05d",opt.fname,opt.ramsessnapname,i+1);
-        sprintf(buf2,"%s/amr_%s.out%s",opt.fname,opt.ramsessnapname);
+        sprintf(buf1,"%s/amr_%s.out%05d",opt.fname,opt.ramsessnapname,i+1);
+        sprintf(buf2,"%s/amr_%s.out",opt.fname,opt.ramsessnapname);
         if (FileExists(buf1)) sprintf(buf,"%s",buf1);
         else if (FileExists(buf2)) sprintf(buf,"%s",buf2);
         Famr[i].open(buf, ios::binary|ios::in);


### PR DESCRIPTION
Fixes a missing semi-column that prevents compilation when running with VR_NO_MASS.

I also fixed a bunch of GCC warnings related to incorrect typecast in printf(). 