### PR TITLE
Fix for running with VR_NO_MASS and swift interface

### DIFF
--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -178,12 +178,6 @@ int InitVelociraptor(char* configname, unitinfo u, siminfo s, const int numthrea
     //set if cosmological
     libvelociraptorOpt.icosmologicalin = s.icosmologicalsim;
 
-    //store a general mass unit, useful if running uniform box with single mass
-    //and saving memory by not storing mass per particle.
-    #ifdef NOMASS
-    libvelociraptorOpt.MassValue = s.mass_uniform_box;
-    #endif
-
     //write velociraptor configuration info, appending .configuration to the input config file and writing every config option
     libvelociraptorOpt.outname = configname;
 
@@ -257,12 +251,6 @@ int InitVelociraptorExtra(const int iextra, char* configname, unitinfo u, siminf
 
     //set if cosmological
     libvelociraptorOptextra[iextra].icosmologicalin = s.icosmologicalsim;
-
-    //store a general mass unit, useful if running uniform box with single mass
-    //and saving memory by not storing mass per particle.
-    #ifdef NOMASS
-    libvelociraptorOptextra[iextra].MassValue = s.mass_uniform_box;
-    #endif
 
     //write velociraptor configuration info, appending .configuration to the input config file and writing every config option
     libvelociraptorOptextra[iextra].outname = configname;
@@ -413,6 +401,12 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
 
     libvelociraptorOpt.outname = outputname;
     libvelociraptorOpt.snapshotvalue = HALOIDSNVAL* snapnum;
+
+    //store a general mass unit, useful if running uniform box with single mass
+    //and saving memory by not storing mass per particle.
+#ifdef NOMASS
+    libvelociraptorOpt.MassValue = s.mass_uniform_box;
+#endif
 
     //write associated units and simulation details (which contains scale factor/time information)
     SetVelociraptorSimulationState(c, s);


### PR DESCRIPTION
This is my attempt to make sure that siminfo.mass_uniform_box is read out by velociraptor AFTER swift has set the value. This is necessary when running with VR_NO_MASS=ON and using the swift interface.