### PR TITLE
Prevent hang in MPIBuildParticleExportListUsingMesh

### DIFF
--- a/src/mpiroutines.cxx
+++ b/src/mpiroutines.cxx
@@ -2846,6 +2846,10 @@ void MPIBuildParticleExportListUsingMesh(Options &opt, const Int_t nbodies, Part
             if (mpi_nsend[ThisTask+recvTask*NProcs] >= maxNumPart || nsend_local[recvTask] >= maxNumPart ) bufferFlag++;
         }
     }
+
+    // Ensure bufferflag is the same over all ranks
+    MPI_Allreduce(MPI_IN_PLACE, &bufferFlag, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+
     //if buffer is too large, split sends
     if (bufferFlag)
     {


### PR DESCRIPTION
This is my attempt at fixing #72. The variable bufferFlag indicates whether communications need to be split and the code executes one of two possible branches depending on the value. In some cases the value varies between MPI ranks, which causes a hang because the communication calls don't match between ranks.

This PR just sets bufferFlag to the maximum value it has across all ranks using an allreduce call. A 150Mpc 2256^3 dmonly box which previously hung on the third snapshot has now produced 25 snapshots without hanging.