### PR TITLE
Removed the SINGLEPRECISION flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ vr_option(ALLOWCOMPRESSIONPARALLELHDF5 "Attempt to include parallel HDF5 compres
 vr_option(XDR  "XDR input support (used by nchilada)" OFF)
 
 # Precision options
-vr_option(SINGLE_PRECISION  "Use single point precision to store all properties and perform all calculations" OFF)
 vr_option(LONG_INT          "Use long ints to represent all integers. Needed if dealing with more than MAXINT number of particles" ON)
 
 # OpenMP options
@@ -121,9 +120,6 @@ endif()
 if (VR_LONG_INT)
 	set(NBODY_LONG_INT ON)
 endif()
-if (VR_SINGLE_PRECISION)
-	set(NBODY_SINGLE_PRECISION ON)
-endif()
 if (VR_USE_LARGE_KDTREE)
 	set(NBODY_USE_LARGE_KDTREE ON)
 endif()
@@ -149,7 +145,6 @@ endmacro()
 
 vr_option_defines(XDR                       USEXDR)
 
-vr_option_defines(SINGLE_PRECISION          SINGLEPRECISION)
 vr_option_defines(LONG_INT                  LONGINT)
 
 vr_option_defines(OPENMP                    USEOPENMP)
@@ -356,8 +351,7 @@ if (VR_HAS_COMPRESSED_HDF5  AND VR_HAS_PARALLEL_HDF5)
 	message("\n WARNING: Parallel Compression HDF5 active, use with caution as it is unstable!\n")
 endif()
 vr_report("Precision-specifics"
-        "Long Integers" LONG_INT
-        "Single precision floats" SINGLE_PRECISION)
+        "Long Integers" LONG_INT)
 vr_report("OpenMP-specifics"
         "OpenMP support" OPENMP)
 vr_report("MPI-specifics"

--- a/src/endianutils.h
+++ b/src/endianutils.h
@@ -223,13 +223,8 @@ inline void InitEndian( void )
     LittleFloat = FloatNoSwap;
     BigDouble = DoubleSwap;
     LittleDouble = DoubleNoSwap;
-#ifdef SINGLEPRECISION
-    LittleDouble_t=FloatNoSwap;
-    BigDouble_t=FloatSwap;
-#else
     LittleDouble_t=DoubleNoSwap;
     BigDouble_t=DoubleSwap;
-#endif
 
 #ifdef GADGETDOUBLEPRECISION
     BigFLOAT= DoubleSwap;
@@ -270,13 +265,8 @@ inline void InitEndian( void )
     LittleFloat = FloatSwap;
     BigDouble = DoubleNoSwap;
     LittleDouble = DoubleSwap;
-#ifdef SINGLEPRECISION
-    LittleDouble_t=FloatSwap;
-    BigDouble_t=FloatNoSwap;
-#else
     LittleDouble_t=DoubleSwap;
     BigDouble_t=DoubleNoSwap;
-#endif
 #ifdef GADGETDOUBLEPRECISION
     BigFLOAT= DoubleNoSwap;
     LittleFLOAT = DoubleSwap;

--- a/src/mpivar.h
+++ b/src/mpivar.h
@@ -76,12 +76,7 @@ typedef short short_mpi_t;
 #define MPI_Int_t MPI_INT
 #define MPI_UInt_t MPI_UNSIGNED
 #endif
-#ifdef SINGLEPRECISION
-#define MPI_Real_t MPI_FLOAT
-#else
 #define MPI_Real_t MPI_DOUBLE
-#endif
-
 //@}
 
 /// \name definitions for MPI message flags


### PR DESCRIPTION
This flag meant that all the calculations would use floats, but it was found
that the loss in precision meant that the code so of the calculations may
produce slightly different results each time it was run. To ensure more
consistency this flag and the use of floats in calculations have been removed.