### PR TITLE
Added while loop to find the first non central particle

### DIFF
--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -6486,7 +6486,7 @@ Int_t CalculateSphericalOverdensity(Options &opt, PropData &pdata,
     vector<Double_t> &SOlgrhovals)
 {
     //Set the start point as the 3rd particle as the 1st particle can have a r=0
-    int minnum=2;
+    int minnum=1;
     int iindex=radii.size();
     //if the lowest overdensity threshold is below the density at the outer
     //edge then extrapolate density based on average slope using 10% of radial bins
@@ -6509,6 +6509,10 @@ Int_t CalculateSphericalOverdensity(Options &opt, PropData &pdata,
         if (j<lindex) EncMass+=massval;
     }
     fac=-log(4.0*M_PI/3.0);
+
+    //Loop over particles to find the first non-central particle
+    while(radii[indices[minnum]]==0) minnum++;
+
     //now find radii matching SO density thresholds
 #ifndef NOMASS
     EncMass=0;for (auto j=0;j<minnum;j++) EncMass+=masses[indices[j]];
@@ -6517,8 +6521,10 @@ Int_t CalculateSphericalOverdensity(Options &opt, PropData &pdata,
     EncMass=0;for (auto j=0;j<minnum;j++) EncMass+=opt.MassValue;
     MinMass=opt.MassValue;
 #endif
-    rc=radii[indices[minnum-1]];
+
+    rc=radii[indices[minnum]];
     llindex=radii.size();
+
     //store old radius, old enclosed mass and ln density
     rc2=rc;
     EncMass2=EncMass;
@@ -6635,8 +6641,8 @@ Int_t CalculateSphericalOverdensity(Options &opt, PropData &pdata,
     Double_t &m200val, Double_t &m200mval, Double_t &mBN98val, Double_t &virval, Double_t &m500val,
     vector<Double_t> &SOlgrhovals)
 {
-    //Set the start point as the 3rd particle as the 1st particle can have a r=0
-    int minnum=2;
+    //Set the start point as the 2nd particle as the 1st particle can have a r=0
+    int minnum=1;
     int iindex=numingroup;
     //if the lowest overdensity threshold is below the density at the outer
     //edge then extrapolate density based on average slope using 10% of radial bins
@@ -6647,6 +6653,9 @@ Int_t CalculateSphericalOverdensity(Options &opt, PropData &pdata,
     int lindex=0.9*iindex, llindex=iindex;
     int iSOfound = 0;
 
+    //Loop over particles to find the first non-central particle
+    while(Part[minnum].Radius()==0) minnum++;
+
     EncMass=0;
     for (auto j=0;j<minnum;j++) {
         massval=Part[j].GetMass();
@@ -6656,8 +6665,8 @@ Int_t CalculateSphericalOverdensity(Options &opt, PropData &pdata,
         EncMass+=massval;
     }
     MinMass=Part[0].GetMass();
-    rc=Part[minnum-1].GetMass();
-    llindex=numingroup;
+    rc=Part[minnum].Radius();
+    llindex= numingroup;
     //store old radius, old enclosed mass and ln density
     rc2=rc;
     EncMass2=EncMass;


### PR DESCRIPTION
In zoom sims, there can be multiple central particles, this while
loop ensures that the first non-central particle is found.