### PR TITLE
Correction to non-assigned variable

### DIFF
--- a/src/localfield.cxx
+++ b/src/localfield.cxx
@@ -563,7 +563,7 @@ private(i,j,k,tid,id,v2,nnids,nnr2,weight,pqv)
             bool ioverlap;
 
             if (opt.impiusemesh) ioverlap = (MPISearchForOverlapUsingMesh(opt,Part[i],maxrdist[i])!=0);
-            else (MPISearchForOverlap(Part[i],maxrdist[i])!=0);
+            else ioverlap = (MPISearchForOverlap(Part[i],maxrdist[i])!=0);
             if (ioverlap) {
                 Part[i].SetDensity(-1.0);
                 continue;


### PR DESCRIPTION
A flag to say if a region had a overlap with another MPI thread was not assigned
if mesh decompostion was not used, meaning that the incorrect nearest neighbour
particles were found.