### PR TITLE
Development

### DIFF
--- a/src/search.cxx
+++ b/src/search.cxx
@@ -1049,6 +1049,17 @@ Int_t* SearchSubset(Options &opt, const Int_t nbodies, const Int_t nsubset, Part
     param[2]=(opt.ellvscale*opt.ellvscale)*(opt.ellvel*opt.ellvel);
     param[6]=(opt.ellxscale*opt.ellxscale)*(opt.ellphys*opt.ellphys);
     param[7]=(opt.Vratio);
+
+    // Need to sort particles as during MPI particle sendrecv the order
+    // might change and can produce sightly different results
+    int * storeval  = new int [nsubset];
+    for(int i = 0; i < nsubset; i++) 
+    {
+      storeval[i] = Partsubset[i].GetType();
+      Partsubset[i].SetType(i);
+    }
+    qsort(Partsubset, nsubset, sizeof(Particle), PIDCompare);
+
     if (opt.foftype==FOF6DSUBSET) {
         param[2] = opt.HaloSigmaV*(opt.halocorevfac * opt.halocorevfac);
         param[7] = param[2];
@@ -1402,7 +1413,7 @@ private(i,tid)
     }
     if (numgroups>0) if (opt.iverbose>=2) cout<<ThisTask<<": "<<numgroups<<" substructures found"<<endl;
     else {if (opt.iverbose>=2) cout<<ThisTask<<": "<<"NO SUBSTRUCTURES FOUND"<<endl;}
-
+    
     //now search particle list for large compact substructures that are considered part of the background when using smaller grids
     if (nsubset>=MINSUBSIZE && opt.iLargerCellSearch && opt.foftype!=FOF6DCORE)
     {
@@ -1897,7 +1908,23 @@ private(i,tid)
 #ifdef USEMPI
     }
 #endif
+    // Return particles to original order, so that the uber-pfof array is not
+    // affected
+    int * tmpfof = new int [nsubset];
+    for (i = 0; i < nsubset; i++)  tmpfof[Partsubset[i].GetType()] = pfof[i];
+    qsort(Partsubset, nsubset, sizeof(Particle), TypeCompare);
+
+    for (i = 0; i < nsubset; i++)
+    { 
+      pfof[i] = tmpfof[i];
+      Partsubset[i].SetType(storeval[i]);
+      Partsubset[i].SetID(i);
+    }
+    delete [] storeval;
+    delete [] tmpfof;
+
     if (opt.iverbose>=2) cout<<"Done search for substructure in this subset"<<endl;
+
     return pfof;
 }
 
@@ -2697,7 +2724,7 @@ inline void PreCalcSearchSubSet(Options &opt, Int_t subnumingroup,  Particle *&s
         FillTreeGrid(opt, subnumingroup, ngrid, tree, subPart, grid);
         gvel=GetCellVel(opt,subnumingroup,subPart,ngrid,grid);
         gveldisp=GetCellVelDisp(opt,subnumingroup,subPart,ngrid,grid,gvel);
-
+        
         opt.HaloLocalSigmaV=0;
         for (auto j=0;j<ngrid;j++) opt.HaloLocalSigmaV+=pow(gveldisp[j].Det(),1./3.);opt.HaloLocalSigmaV/=(double)ngrid;
 
@@ -2965,6 +2992,22 @@ void SearchSubSub(Options &opt, const Int_t nsubset, vector<Particle> &Partsubse
             CleanAndUpdateGroupsFromSubSearch(opt, subnumingroup[i], subPart, subpfof,
                     subngroup[i], subsubnumingroup[i], subsubpglist[i], numcores[i],
                     subpglist[i], pfof, ngroup, ngroupidoffset_old[i]);
+//---
+if (subnumingroup[i] == 2539)
+{
+ char bufff [1000];
+ bufff[0] = '\0';
+ char tmpbf [100];
+ sprintf (tmpbf, "Nbodies %d  subngroup %d ningroups ", subnumingroup[i], subngroup[i]);
+ strcat(bufff, tmpbf);
+ for (int i = 0; i < subngroup[i]; i++)
+ {
+  sprintf(tmpbf, "%d  ", subsubnumingroup[i]);
+  strcat(bufff, tmpbf);
+ }
+ printf ("ThisTask %d  %s\n", ThisTask, bufff);
+}
+//---
             delete[] subpfof;
             delete[] subPart;
             ns+=subngroup[i];
@@ -3337,7 +3380,8 @@ private(i)
                         if(Partsubset[pglist[i][j]].GetPotential()>vminell&&Partsubset[pglist[i][j]].GetPotential()<minell[i])minell[i]=Partsubset[pglist[i][j]].GetPotential();
                         else if (Partsubset[pglist[i][j]].GetPotential()==vminell) iminell=j;
                     pfof[Partsubset[pglist[i][iminell]].GetID()]=0;
-                    if (iminell!=numingroup[i]-1)pglist[i][iminell]=pglist[i][--numingroup[i]];
+                    if (iminell!=numingroup[i]-1)pglist[i][iminell]=pglist[i][numingroup[i]-1];
+                    numingroup[i]--;
                     betaave[i]=(aveell[i]/ellaveexp-1.0)*sqrt((Double_t)numingroup[i]);
                 } while(betaave[i]<opt.siglevel);
             }

--- a/src/search.cxx
+++ b/src/search.cxx
@@ -2992,22 +2992,6 @@ void SearchSubSub(Options &opt, const Int_t nsubset, vector<Particle> &Partsubse
             CleanAndUpdateGroupsFromSubSearch(opt, subnumingroup[i], subPart, subpfof,
                     subngroup[i], subsubnumingroup[i], subsubpglist[i], numcores[i],
                     subpglist[i], pfof, ngroup, ngroupidoffset_old[i]);
-//---
-if (subnumingroup[i] == 2539)
-{
- char bufff [1000];
- bufff[0] = '\0';
- char tmpbf [100];
- sprintf (tmpbf, "Nbodies %d  subngroup %d ningroups ", subnumingroup[i], subngroup[i]);
- strcat(bufff, tmpbf);
- for (int i = 0; i < subngroup[i]; i++)
- {
-  sprintf(tmpbf, "%d  ", subsubnumingroup[i]);
-  strcat(bufff, tmpbf);
- }
- printf ("ThisTask %d  %s\n", ThisTask, bufff);
-}
-//---
             delete[] subpfof;
             delete[] subPart;
             ns+=subngroup[i];


### PR DESCRIPTION
Minor bug fixed.

In some circumstances, when particles are sent across MPI domains, the list of particles of the same 6DFOF object end up in different order. This can change the number of particles assigned to substructures during linking when two substructures have the same number of particles. A particle can be assigned to either substructure in a "first come, first served" fashion.

The proposed solution is to sort particles before this assignment happens at the beginning of SearchSubSet, and the particle array is sorted back at the end of the function to be consistent with the larger pfof array.