### PR TITLE
Fix bugs in return of group IDs to Swift

### DIFF
--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -761,12 +761,20 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
     delete [] pfof;
 #ifdef USEMPI
     if (NProcs > 1) {
-        for (auto i=0;i<Nlocal; i++) parts[i].SetID((parts[i].GetSwiftTask()==ThisTask));
+        for (auto i=0;i<Nlocal; i++) parts[i].SetID((parts[i].GetSwiftTask()!=ThisTask));
         //now sort items according to whether local swift task
-        qsort(parts.data(), nig, sizeof(Particle), IDCompare);
+        qsort(parts.data(), Nlocal, sizeof(Particle), IDCompare);
         //communicate information
         MPISwiftExchange(parts);
         Nlocal = parts.size();
+
+        for (auto i=0;i<Nlocal; i++) {
+          if(parts[i].GetSwiftTask() != ThisTask) {
+            cout << "Particle on wrong task!";
+            MPI_Abort(MPI_COMM_WORLD, 1);
+          }
+        }
+
     }
 #endif
     qsort(parts.data(), Nlocal, sizeof(Particle), PIDCompare);


### PR DESCRIPTION
When running Velociraptor on the fly in Swift the group index of each particle is written to a dataset in the snapshot file. This output is wrong in the current master versions of swift and velociraptor. Only a small fraction of particles in one corner of the box get assigned group indexes.

So far I believe I've found one bug in swift (see https://gitlab.cosma.dur.ac.uk/swift/swiftsim/merge_requests/1116) and two in velociraptor (this pull request) which contribute to this problem. With the changes in these two pull requests the output looks a bit more plausible but it's still wrong.

The velociraptor bugs I've spotted are:

  * In swiftinterface.cxx just before the call to MPISwiftExchange the particles are sorted. It looks as though particles to be exported should be put at the end of the particle array but the code puts them at the start.

 * The array size passed to qsort when sorting the array is wrong so only part of the array gets sorted.

I also added a check to make sure particles have been returned to the right MPI task. This check now passes, but there's still something wrong somewhere.