### PR TITLE
Fix for ordering of particles when returning Velociraptor group IDs to Swift

### DIFF
--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -762,20 +762,6 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
         return NULL;
     }
 
-    // // Dump particle data for testing
-    // ofstream testfile;
-    // testfile.open ("particles.txt");
-    // for (auto i=0;i<Nlocal; i++) {
-    //   testfile << parts[i].GetPID() << ", " << (pfof[i]+ngoffset) << "\n";
-    // }
-    // testfile.close();
-
-    //move particles back to original swift task
-    //store group id
-    // for (auto i=0;i<Nlocal; i++) {
-    //     if (pfof[i]>0) parts[i].SetPID((pfof[i]+ngoffset)+libvelociraptorOpt.snapshotvalue);
-    //     else parts[i].SetPID(0);
-    // }
     delete [] pfof;
 #ifdef USEMPI
     if (NProcs > 1) {

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -700,6 +700,26 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
     //assuming that the swift task and swift index can be used to determine where a particle will be written.
     if (ireturngroupinfoflag != 1 ) WriteSwiftExtendedOutput (libvelociraptorOpt, ngroup, numingroup, pglist, parts);
 
+    // Find offset to first group on each MPI rank
+    Int_t ngoffset=0,ngtot=0;
+    Int_t nig=0;
+    ngtot=ngroup;
+#ifdef USEMPI
+    if (NProcs > 1) {
+        ngtot = 0;
+        for (auto j=0;j<ThisTask;j++)ngoffset+=mpi_ngroups[j];
+        for (auto j=0;j<NProcs;j++)ngtot+=mpi_ngroups[j];
+    }
+#endif
+
+    // Compute group membership for each particle and store in PID
+    for (auto i=0; i<Nlocal; i++)parts[i].SetPID(0);
+    for (auto i=1; i<=ngroup; i++) {
+      for (auto j=0;j<numingroup[i];j++) {
+        parts[pglist[i][j]].SetPID(i+ngoffset+libvelociraptorOpt.snapshotvalue);
+      }
+    }
+
     for (Int_t i=1;i<=ngroup;i++) delete[] pglist[i];
     delete[] pglist;
     delete[] pdata;
@@ -728,17 +748,6 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
     }
 
     //first sort so all particles in groups first
-    Int_t ngoffset=0,ngtot=0;
-    Int_t nig=0;
-
-    ngtot=ngroup;
-#ifdef USEMPI
-    if (NProcs > 1) {
-        ngtot = 0;
-        for (auto j=0;j<ThisTask;j++)ngoffset+=mpi_ngroups[j];
-        for (auto j=0;j<NProcs;j++)ngtot+=mpi_ngroups[j];
-    }
-#endif
     cout<<"VELOCIraptor sorting info to return group ids to swift"<<endl;
     if (ngtot == 0) {
         cout<<"No groups found"<<endl;
@@ -752,12 +761,21 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
         *numpartingroups=nig;
         return NULL;
     }
+
+    // // Dump particle data for testing
+    // ofstream testfile;
+    // testfile.open ("particles.txt");
+    // for (auto i=0;i<Nlocal; i++) {
+    //   testfile << parts[i].GetPID() << ", " << (pfof[i]+ngoffset) << "\n";
+    // }
+    // testfile.close();
+
     //move particles back to original swift task
     //store group id
-    for (auto i=0;i<Nlocal; i++) {
-        if (pfof[i]>0) parts[i].SetPID((pfof[i]+ngoffset)+libvelociraptorOpt.snapshotvalue);
-        else parts[i].SetPID(0);
-    }
+    // for (auto i=0;i<Nlocal; i++) {
+    //     if (pfof[i]>0) parts[i].SetPID((pfof[i]+ngoffset)+libvelociraptorOpt.snapshotvalue);
+    //     else parts[i].SetPID(0);
+    // }
     delete [] pfof;
 #ifdef USEMPI
     if (NProcs > 1) {


### PR DESCRIPTION
When running on the fly from Swift and writing Velociraptor group IDs to the snapshot, the resulting dataset is scrambled. This happens because the particles are sorted by binding energy but the corresponding pfof array which stores the group membership is not reordered.

With this change the VELOCIraptorGroupIDs array in Swift outputs is correct when running on one MPI rank. On multiple ranks VELOCIraptorGroupIDs does not agree with the velociraptor output files so there's at least one more bug left.