### PR TITLE
Resize Part vector before updating it in MPISwiftExchange() to avoid out of bounds access

### DIFF
--- a/src/mpiroutines.cxx
+++ b/src/mpiroutines.cxx
@@ -5730,12 +5730,12 @@ void MPISwiftExchange(vector<Particle> &Part){
     }
     }
     MPI_Barrier(MPI_COMM_WORLD);
+    Part.resize(nbodies-nexport+nimport);
     if (nexport > 0) delete[] PartBufSend;
     if (nimport > 0) {
         for (i=0;i<nimport;i++) Part[i+nbodies-nexport]=PartBufRecv[i];
         delete[] PartBufRecv;
     }
-    Part.resize(nbodies-nexport+nimport);
 }
 
 #endif


### PR DESCRIPTION
This fixes an inconsistency between the Velociraptor output files and the snapshot when running on the fly in a Swift simulation.