### PR TITLE
Return most bound particle indexes when running on the fly in Swift

### DIFF
--- a/src/mpiroutines.cxx
+++ b/src/mpiroutines.cxx
@@ -5730,12 +5730,12 @@ void MPISwiftExchange(vector<Particle> &Part){
     }
     }
     MPI_Barrier(MPI_COMM_WORLD);
+    Part.resize(nbodies-nexport+nimport);
     if (nexport > 0) delete[] PartBufSend;
     if (nimport > 0) {
         for (i=0;i<nimport;i++) Part[i+nbodies-nexport]=PartBufRecv[i];
         delete[] PartBufRecv;
     }
-    Part.resize(nbodies-nexport+nimport);
 }
 
 #endif

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -463,7 +463,6 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     Int_t *nsub = NULL, *parentgid = NULL, *uparentgid =NULL, *stype = NULL;
     Int_t nbaryons, ndark, index;
     Int_t ngroup, nhalos;
-    groupinfo *group_info = NULL;
     //KDTree *tree;
     //to store information about the group
     PropData *pdata = NULL,*pdatahalos = NULL;
@@ -700,13 +699,13 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
 #ifdef EXTENDEDHALOOUTPUT
     if (opt.iExtendedOutput) WriteExtendedOutput (libvelociraptorOpt, ngroup, nbodies, pdata, parts, pfof);
 #endif
+    delete[] pfof;
     //if returning to swift as swift is writing a snapshot, then write for the groups where the particles are found in a file
     //assuming that the swift task and swift index can be used to determine where a particle will be written.
     if (ireturngroupinfoflag != 1 ) WriteSwiftExtendedOutput (libvelociraptorOpt, ngroup, numingroup, pglist, parts);
 
     // Find offset to first group on each MPI rank
     Int_t ngoffset=0,ngtot=0;
-    Int_t nig=0;
     ngtot=ngroup;
 #ifdef USEMPI
     if (NProcs > 1) {
@@ -737,67 +736,46 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     //get memory usage
     GetMemUsage(libvelociraptorOpt, __func__+string("--line--")+to_string(__LINE__), true);
 
-    //store group information to return information to swift if required
-    //otherwise, return NULL as pointer
-    if (ireturngroupinfoflag != 1 ) {
-        cout<<"VELOCIraptor returning, no group info returned to swift as requested."<< endl;
-        //free mem associate with mpi cell node ides
-        libvelociraptorOpt.cellnodeids = NULL;
-        libvelociraptorOpt.cellloc = NULL;
-        free(s.cellloc);
-        free(cell_node_ids);
-        delete[] pfof;
-        return return_data;
-    }
-
-    //first sort so all particles in groups first
-    cout<<"VELOCIraptor sorting info to return group ids to swift"<<endl;
-    if (ngtot == 0) {
-        cout<<"No groups found"<<endl;
-        //free mem associate with mpi cell node ides
-        libvelociraptorOpt.cellnodeids = NULL;
-        libvelociraptorOpt.cellloc = NULL;
-        free(s.cellloc);
-        free(cell_node_ids);
-        delete[] pfof;
-        parts.clear();
-        return_data.num_gparts_in_groups=nig;
-        return return_data;
-    }
-
-    delete [] pfof;
+    // Compute group_info array if we have groups and it was requested
+    groupinfo *group_info = NULL;
+    Int_t nig=0;
+    if(ireturngroupinfoflag && ngtot > 0) {
+      //first sort so all particles in groups first
+      cout<<"VELOCIraptor sorting info to return group ids to swift"<<endl;
 #ifdef USEMPI
-    if (NProcs > 1) {
+      if (NProcs > 1) {
         for (auto i=0;i<Nlocal; i++) parts[i].SetID((parts[i].GetSwiftTask()!=ThisTask));
         //now sort items according to whether local swift task
         qsort(parts.data(), Nlocal, sizeof(Particle), IDCompare);
         //communicate information
         MPISwiftExchange(parts);
         Nlocal = parts.size();
-
+        
         for (auto i=0;i<Nlocal; i++) {
           if(parts[i].GetSwiftTask() != ThisTask) {
             cout << "Particle on wrong task!";
             MPI_Abort(MPI_COMM_WORLD, 1);
           }
-        }
-
-    }
+        } 
+      }
 #endif
-    qsort(parts.data(), Nlocal, sizeof(Particle), PIDCompare);
-    nig=0;
-    Int_t istart=0;
-    for (auto i=0;i<Nlocal;i++) if (parts[i].GetPID()>0) {nig=Nlocal-i;istart=i;break;}
-    return_data.num_gparts_in_groups=nig;
-    group_info=NULL;
-    if (nig>0)
-    {
-      group_info = (groupinfo *) malloc(nig*sizeof(struct groupinfo)); // Will be freed by Swift
-        for (auto i=istart;i<Nlocal;i++) {
+      qsort(parts.data(), Nlocal, sizeof(Particle), PIDCompare);
+      nig=0;
+      Int_t istart=0;
+      for (auto i=0;i<Nlocal;i++) if (parts[i].GetPID()>0) {nig=Nlocal-i;istart=i;break;}
+      if (nig>0)
+        {
+          group_info = (groupinfo *) malloc(nig*sizeof(struct groupinfo)); // Will be freed by Swift
+          for (auto i=istart;i<Nlocal;i++) {
             group_info[i-istart].index=parts[i].GetSwiftIndex();
             group_info[i-istart].groupid=parts[i].GetPID();
+          }
         }
     }
+    // Add groupinfo to struct to return
+    return_data.num_gparts_in_groups=nig;
+    return_data.group_info = group_info;
+
     cout<<"VELOCIraptor returning."<< endl;
 
     //free mem associate with mpi cell node ides
@@ -806,9 +784,6 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     free(s.cellloc);
     free(cell_node_ids);
     parts.clear();
-
-    // Add groupinfo to struct to return
-    return_data.group_info = group_info;
 
     return return_data;
 }

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -429,10 +429,10 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     nthreads=1;
 #endif
 
-    // Construct return value
+    // Construct default return value
     vr_return_data return_data;
-    return_data.numingroups = 0;
-    return_data.groupinfo = NULL;
+    return_data.num_gparts_in_groups = 0;
+    return_data.group_info = NULL;
     return_data.num_most_bound = 0;
     return_data.most_bound_index = NULL;
 
@@ -761,7 +761,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
         free(cell_node_ids);
         delete[] pfof;
         parts.clear();
-        return_data.numingroups=nig;
+        return_data.num_gparts_in_groups=nig;
         return return_data;
     }
 
@@ -788,7 +788,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     nig=0;
     Int_t istart=0;
     for (auto i=0;i<Nlocal;i++) if (parts[i].GetPID()>0) {nig=Nlocal-i;istart=i;break;}
-    return_data.numingroups=nig;
+    return_data.num_gparts_in_groups=nig;
     group_info=NULL;
     if (nig>0)
     {
@@ -808,7 +808,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     parts.clear();
 
     // Add groupinfo to struct to return
-    return_data.groupinfo = group_info;
+    return_data.group_info = group_info;
 
     return return_data;
 }

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -794,7 +794,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     group_info=NULL;
     if (nig>0)
     {
-      group_info = new groupinfo[nig];
+      group_info = (groupinfo *) malloc(nig*sizeof(struct groupinfo)); // Will be freed by Swift
         for (auto i=istart;i<Nlocal;i++) {
             group_info[i-istart].index=parts[i].GetSwiftIndex();
             group_info[i-istart].groupid=parts[i].GetPID();

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -388,14 +388,14 @@ extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* out
     cosmoinfo c, siminfo s,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound
 )
 {
     const size_t num_bh_parts = 0;
     vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
         swift_parts, cell_node_ids,
-        numthreads, ireturngroupinfoflag);
+        numthreads, ireturngroupinfoflag, ireturnmostbound);
     return return_data;
 }
 vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
@@ -403,7 +403,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
-    const int ireturngroupinfoflag,
+    const int ireturngroupinfoflag, const int ireturnmostbound,
     struct swift_vel_gas_part *swift_gas_parts,
     struct swift_vel_star_part *swift_star_parts,
     struct swift_vel_bh_part *swift_bh_parts
@@ -820,7 +820,7 @@ vr_return_data InvokeVelociraptorExtra(const int iextra, const int snapnum, char
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
-    const int ireturngroupinfoflag)
+    const int ireturngroupinfoflag, const int ireturnmostbound)
 {
     //store backup of the libvelociraptorOpt
     libvelociraptorOptbackup = libvelociraptorOpt;
@@ -829,7 +829,7 @@ vr_return_data InvokeVelociraptorExtra(const int iextra, const int snapnum, char
         num_gravity_parts, num_hydro_parts, num_star_parts,
         swift_parts, cell_node_ids,
         numthreads,
-        ireturngroupinfoflag);
+        ireturngroupinfoflag, ireturnmostbound);
     libvelociraptorOpt = libvelociraptorOptbackup;
     return return_data;
 }
@@ -839,7 +839,7 @@ vr_return_data InvokeVelociraptorHydroExtra(const int iextra, const int snapnum,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
-    const int ireturngroupinfoflag,
+    const int ireturngroupinfoflag, const int ireturnmostbound,
     struct swift_vel_gas_part *swift_gas_parts,
     struct swift_vel_star_part *swift_star_parts,
     struct swift_vel_bh_part *swift_bh_parts
@@ -850,7 +850,7 @@ vr_return_data InvokeVelociraptorHydroExtra(const int iextra, const int snapnum,
     libvelociraptorOpt = libvelociraptorOptextra[iextra];
     vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
-        swift_parts, cell_node_ids, numthreads, ireturngroupinfoflag,
+        swift_parts, cell_node_ids, numthreads, ireturngroupinfoflag, ireturnmostbound,
         swift_gas_parts, swift_star_parts, swift_bh_parts);
     libvelociraptorOpt = libvelociraptorOptbackup;
     return return_data;

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -388,15 +388,14 @@ extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* out
     cosmoinfo c, siminfo s,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numpartingroups
+    const int numthreads, const int ireturngroupinfoflag
 )
 {
     const size_t num_bh_parts = 0;
     vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
         swift_parts, cell_node_ids,
-        numthreads, ireturngroupinfoflag,
-        numpartingroups);
+        numthreads, ireturngroupinfoflag);
     return return_data;
 }
 vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
@@ -405,7 +404,6 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
     const int ireturngroupinfoflag,
-    int * const numpartingroups,
     struct swift_vel_gas_part *swift_gas_parts,
     struct swift_vel_star_part *swift_star_parts,
     struct swift_vel_bh_part *swift_bh_parts
@@ -433,6 +431,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
 
     // Construct return value
     vr_return_data return_data;
+    return_data.numingroups = 0;
     return_data.groupinfo = NULL;
     return_data.num_most_bound = 0;
     return_data.most_bound_index = NULL;
@@ -748,7 +747,6 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
         free(s.cellloc);
         free(cell_node_ids);
         delete[] pfof;
-        *numpartingroups=0;
         return return_data;
     }
 
@@ -763,7 +761,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
         free(cell_node_ids);
         delete[] pfof;
         parts.clear();
-        *numpartingroups=nig;
+        return_data.numingroups=nig;
         return return_data;
     }
 
@@ -790,7 +788,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     nig=0;
     Int_t istart=0;
     for (auto i=0;i<Nlocal;i++) if (parts[i].GetPID()>0) {nig=Nlocal-i;istart=i;break;}
-    *numpartingroups=nig;
+    return_data.numingroups=nig;
     group_info=NULL;
     if (nig>0)
     {
@@ -822,8 +820,7 @@ vr_return_data InvokeVelociraptorExtra(const int iextra, const int snapnum, char
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
-    const int ireturngroupinfoflag,
-    int * const numpartingroups)
+    const int ireturngroupinfoflag)
 {
     //store backup of the libvelociraptorOpt
     libvelociraptorOptbackup = libvelociraptorOpt;
@@ -832,8 +829,7 @@ vr_return_data InvokeVelociraptorExtra(const int iextra, const int snapnum, char
         num_gravity_parts, num_hydro_parts, num_star_parts,
         swift_parts, cell_node_ids,
         numthreads,
-        ireturngroupinfoflag,
-        numpartingroups);
+        ireturngroupinfoflag);
     libvelociraptorOpt = libvelociraptorOptbackup;
     return return_data;
 }
@@ -844,7 +840,6 @@ vr_return_data InvokeVelociraptorHydroExtra(const int iextra, const int snapnum,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
     const int ireturngroupinfoflag,
-    int * const numpartingroups,
     struct swift_vel_gas_part *swift_gas_parts,
     struct swift_vel_star_part *swift_star_parts,
     struct swift_vel_bh_part *swift_bh_parts
@@ -856,7 +851,6 @@ vr_return_data InvokeVelociraptorHydroExtra(const int iextra, const int snapnum,
     vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
         swift_parts, cell_node_ids, numthreads, ireturngroupinfoflag,
-        numpartingroups,
         swift_gas_parts, swift_star_parts, swift_bh_parts);
     libvelociraptorOpt = libvelociraptorOptbackup;
     return return_data;

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -723,7 +723,6 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
       }
     }
 
-    for (Int_t i=1;i<=ngroup;i++) delete[] pglist[i];
     delete[] pdata;
     delete[] nsub;
     delete[] uparentgid;
@@ -770,6 +769,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     return_data.num_most_bound = num_most_bound;
     return_data.most_bound_index = most_bound_index;
 
+    for (Int_t i=1;i<=ngroup;i++) delete[] pglist[i];
     delete[] pglist;
     delete[] numingroup;
 

--- a/src/swiftinterface.h
+++ b/src/swiftinterface.h
@@ -128,6 +128,8 @@ namespace Swift {
 
     // Data returned when invoking Velociraptor
     struct vr_return_data {
+      // Number of gparts in groups
+      int numingroups;
       // Pointer to group information array, or NULL if not requested
       struct groupinfo *groupinfo;
       // Number of most bound particles returned
@@ -152,13 +154,13 @@ extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* out
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numingroups
+    const int numthreads, const int ireturngroupinfoflag
 );
 extern "C" Swift::vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numingroups,
+    const int numthreads, const int ireturngroupinfoflag,
     struct swift_vel_gas_part *swift_gas_parts = NULL,
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL
@@ -168,7 +170,7 @@ extern "C" Swift::vr_return_data InvokeVelociraptorExtra(const int iextra,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numingroups
+    const int numthreads, const int ireturngroupinfoflag
 );
 extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const int snapnum, char* outputname,
@@ -176,7 +178,7 @@ extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const size_t num_gravity_parts, const size_t num_hydro_parts,
     const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numingroups,
+    const int numthreads, const int ireturngroupinfoflag,
     struct swift_vel_gas_part *swift_gas_parts = NULL,
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL

--- a/src/swiftinterface.h
+++ b/src/swiftinterface.h
@@ -125,6 +125,16 @@ namespace Swift {
       int index;
       long long groupid;
     };
+
+    // Data returned when invoking Velociraptor
+    struct vr_return_data {
+      // Pointer to group information array, or NULL if not requested
+      struct groupinfo *groupinfo;
+      // Number of most bound particles returned
+      int num_most_bound;
+      // Swift gpart indexes of most bound particles, or NULL if not requested
+      int *most_bound_index;
+    };
 }
 
 
@@ -138,13 +148,13 @@ extern "C" int InitVelociraptor(char* configname, Swift::unitinfo, Swift::siminf
 ///initialize velociraptor based on extra possible outputs requested by swift in addition to standard invocation, check configuration options,
 extern "C" int InitVelociraptorExtra(const int iextra, char* configname, Swift::unitinfo, Swift::siminfo, const int numthreads);
 ///actually run velociraptor
-extern "C" Swift::groupinfo * InvokeVelociraptor(const int snapnum, char* outputname,
+extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads, const int ireturngroupinfoflag, int *const numingroups
 );
-extern "C" Swift::groupinfo * InvokeVelociraptorHydro(const int snapnum, char* outputname,
+extern "C" Swift::vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
@@ -153,14 +163,14 @@ extern "C" Swift::groupinfo * InvokeVelociraptorHydro(const int snapnum, char* o
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL
 );
-extern "C" Swift::groupinfo * InvokeVelociraptorExtra(const int iextra,
+extern "C" Swift::vr_return_data InvokeVelociraptorExtra(const int iextra,
     const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads, const int ireturngroupinfoflag, int *const numingroups
 );
-extern "C" Swift::groupinfo * InvokeVelociraptorHydroExtra(const int iextra,
+extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts,

--- a/src/swiftinterface.h
+++ b/src/swiftinterface.h
@@ -154,13 +154,13 @@ extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* out
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound
 );
 extern "C" Swift::vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag,
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound,
     struct swift_vel_gas_part *swift_gas_parts = NULL,
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL
@@ -170,7 +170,7 @@ extern "C" Swift::vr_return_data InvokeVelociraptorExtra(const int iextra,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound
 );
 extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const int snapnum, char* outputname,
@@ -179,6 +179,7 @@ extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads, const int ireturngroupinfoflag,
+    const int ireturnmostbound,
     struct swift_vel_gas_part *swift_gas_parts = NULL,
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL

--- a/src/swiftinterface.h
+++ b/src/swiftinterface.h
@@ -129,9 +129,9 @@ namespace Swift {
     // Data returned when invoking Velociraptor
     struct vr_return_data {
       // Number of gparts in groups
-      int numingroups;
+      int num_gparts_in_groups;
       // Pointer to group information array, or NULL if not requested
-      struct groupinfo *groupinfo;
+      struct groupinfo *group_info;
       // Number of most bound particles returned
       int num_most_bound;
       // Swift gpart indexes of most bound particles, or NULL if not requested


### PR DESCRIPTION
@pelahi - please don't merge this just yet! It requires corresponding changes in Swift and it breaks the existing Swift/VR interface.

This modifies the Swift interface so that Swift can request that Velociraptor return the indexes of the most bound particles in the halos it finds. On the Swift side, we can then use that information to output the particles we need for 'orphan' galaxies in semi-analytic models (i.e. galaxies which are no longer associated with a resolved halo.)

The corresponding merge request on the Swift side is at https://gitlab.cosma.dur.ac.uk/swift/swiftsim/merge_requests/1131.