### PR TITLE
Added features to baryon runs

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -414,7 +414,9 @@ Particles in strutures can be checked to see if they are bound relative to a kin
 This cleans the (sub)structures of spurious objects and particles.
 
     ``Unbind_flag = 1/0``
-        * Flag indciating whether substructures passed through an unbinding routine.
+        * Flag indicating whether substructures passed through an unbinding routine.
+    ``Unbind_Only_With_Baryons flag = 1/0``
+        * Flag indicating whether or not substructures should be passed through an unbinding routine only after having baryons added. This applies to running velociraptor on a simulation containing all different types of particles where substructure is searched using initially dark matter particles before adding baryons in a phase-space search.
     ``Unbinding_type = 1/0``
         * Integer setting the unbinding criteria used. Either just remove particles deemeed "unbound" (**1**), that is those with :math:`\alpha T+W>0` given by ``Allowed_kinetic_potential_ratio``, or (**0**) additionally removes "unbound" and least bound particles till system also has a true bound fraction > ``Min_bound_mass_frac``.
     ``Allowed_kinetic_potential_ratio =``

--- a/src/allvars.h
+++ b/src/allvars.h
@@ -35,6 +35,7 @@
 #include <sys/sysinfo.h>
 #include <sys/timeb.h>
 #include <sys/time.h>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <unistd.h>
@@ -375,6 +376,8 @@ struct UnbindInfo
     Double_t approxpotminnum;
     ///method of subsampling to calculate potential
     int approxpotmethod;
+    /// whether to include baryons before running unbinding in a simulation
+    int iunbindwithbaryons;
     //@}
     UnbindInfo(){
         icalculatepotential=true;
@@ -397,6 +400,7 @@ struct UnbindInfo
         approxpotnumfrac = 0.1;
         approxpotminnum = 5000;
         approxpotmethod = POTAPPROXMETHODTREE;
+        iunbindwithbaryons = 1;
     }
 };
 

--- a/src/ui.cxx
+++ b/src/ui.cxx
@@ -357,6 +357,7 @@ void usage(void)
     See \ref unbinding and \ref unbind.cxx for more details
 
     \arg <b> \e Unbind_flag  </b> whether or not substructures should be passed through an unbinding routine. \ref Options.uinfo & \ref UnbindInfo.unbindflag \n
+    \arg <b> \e Unbind_Only_With_Baryons_flag  </b> whether or not substructures should be passed through an unbinding routine only after having baryons added. This applies to running velociraptor on a simulation containing all different types of particles where substructure is searched using initially dark matter particles before adding baryons in a phase-space search. \ref Options.uinfo & \ref UnbindInfo.iunbindwithbaryons \n
     \arg <b> \e Allowed_kinetic_potential_ratio  </b> ratio of kinetic to potential energy at which a particle is still considered bound, ie: particle is still bound
     if \f$ \alpha T+W<0 \f$, so \f$ \alpha=1 \f$ would be standard unbinding and \f$ \alpha<1 \f$ allows one to identify unbound tidal debris.
     Given that <b> VELOCIraptor </b> was designed to identify tidal streams, it makes little sense to have this set to 1 unless explicitly required.
@@ -1005,6 +1006,8 @@ void GetParamFile(Options &opt)
                     //unbinding
                     else if (strcmp(tbuff, "Unbind_flag")==0)
                         opt.uinfo.unbindflag = atoi(vbuff);
+                    else if (strcmp(tbuff, "Unbind_Only_With_Baryons_flag")==0)
+                        opt.uinfo.iunbindwithbaryons = atoi(vbuff);
                     else if (strcmp(tbuff, "Unbinding_type")==0)
                         opt.uinfo.unbindtype = atoi(vbuff);
                     else if (strcmp(tbuff, "Unbinding_use_thermal_energy")==0)
@@ -1144,8 +1147,10 @@ void GetParamFile(Options &opt)
                         opt.impiusemesh = (atoi(vbuff)>0);
                     else if (strcmp(tbuff, "MPI_zcurve_mesh_decomposition_min_num_cells_per_dim")==0)
                         opt.minnumcellperdim = atoi(vbuff);
-                    else if (strcmp(tbuff, "MPI_zcurve_mesh_decomposition_num_cells_per_dim")==0)
+                    else if (strcmp(tbuff, "MPI_zcurve_mesh_decomposition_num_cells_per_dim")==0) {
                         opt.numcellsperdim = atoi(vbuff);
+                        opt.numcells = opt.numcellsperdim*opt.numcellsperdim*opt.numcellsperdim;
+                    }
                     ///OpenMP related
                     else if (strcmp(tbuff, "OMP_run_fof")==0)
                         opt.iopenmpfof = atoi(vbuff);
@@ -2480,6 +2485,7 @@ ConfigInfo::ConfigInfo(Options &opt){
 
     //unbinding
     AddEntry("Unbind_flag", opt.uinfo.unbindflag);
+    AddEntry("Unbind_With_Only_Baryons_flag", opt.uinfo.iunbindwithbaryons);
     AddEntry("Unbinding_type", opt.uinfo.unbindtype);
     AddEntry("Bound_halos", opt.iBoundHalos);
     AddEntry("Allowed_kinetic_potential_ratio", opt.uinfo.Eratio);


### PR DESCRIPTION
- now by default if running with baryons, code will not run unbinding on substructures till baryons have been associated with substructures. This ensures that very baryon dominated substructures are present in the catalogue. Otherwise, when a dark matter substructure candidate is found, it is possible that the unbinding process will remove it entirely before baryons can be associated with it, leaving unidentified what would be baryon dominated substructures.
- updated the user interface to allow this option to be turn off and documented this option